### PR TITLE
UNet evaluation fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='0.8.2',
+        version='0.8.4',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/picai_baseline/unet/training_setup/callbacks.py
+++ b/src/picai_baseline/unet/training_setup/callbacks.py
@@ -193,6 +193,7 @@ def validate_model(model, optimizer, valid_gen, args, tracking_metrics, device, 
         lesion_results += y_list
 
     # track validation metrics
+    lesion_results = {idx: result for idx, result in enumerate(lesion_results)}
     valid_metrics = Metrics(lesion_results)
 
     num_pos = sum([y == 1 for y in valid_metrics.case_target.values()])

--- a/src/picai_baseline/unet/training_setup/callbacks.py
+++ b/src/picai_baseline/unet/training_setup/callbacks.py
@@ -177,16 +177,17 @@ def validate_model(model, optimizer, valid_gen, args, tracking_metrics, device, 
         # gaussian blur to counteract checkerboard artifacts in
         # predictions from the use of transposed conv. in the U-Net
         preds = np.mean([
-            gaussian_filter(x, sigma=1.5) for x in preds
+            gaussian_filter(x, sigma=1.5)
+            for x in preds
         ], axis=0)
     
         # extract lesion candidates
         preds = [
-            extract_lesion_candidates(preds[x,...])[0] 
-            for x in range(preds.shape[0])
+            extract_lesion_candidates(x)[0] 
+            for x in preds
         ]
 
-        # evaluate batch
+        # evaluate detection maps of batch
         for y_det, y_true in zip(preds, valid_labels):
             y_list, *_ = evaluate_case(
                 y_det=y_det,

--- a/src/picai_baseline/unet/training_setup/callbacks.py
+++ b/src/picai_baseline/unet/training_setup/callbacks.py
@@ -193,8 +193,8 @@ def validate_model(model, optimizer, valid_gen, args, tracking_metrics, device, 
                 y_true=y_true.squeeze(),
             )
 
-        # aggregate all validation evaluations
-        lesion_results.append(y_list)
+            # aggregate all validation evaluations
+            lesion_results.append(y_list)
 
     # track validation metrics
     lesion_results = {idx: result for idx, result in enumerate(lesion_results)}

--- a/src/picai_baseline/unet/training_setup/data_generator.py
+++ b/src/picai_baseline/unet/training_setup/data_generator.py
@@ -121,6 +121,6 @@ def prepare_datagens(args, fold_id):
     train_ldr = DataLoaderFromDataset(train_ds, 
         batch_size=args.batch_size, num_threads=args.num_threads, infinite=True, shuffle=True)
     valid_ldr = DataLoaderFromDataset(valid_ds, 
-        batch_size=args.batch_size, num_threads=1, infinite=False, shuffle=False)
+        batch_size=1, num_threads=1, infinite=False, shuffle=False)
 
     return train_ldr, valid_ldr, class_weights.astype(np.float32)

--- a/src/picai_baseline/unet/training_setup/data_generator.py
+++ b/src/picai_baseline/unet/training_setup/data_generator.py
@@ -21,6 +21,7 @@ import numpy as np
 import torch
 from batchgenerators.dataloading.data_loader import DataLoader
 from monai.transforms import Compose, EnsureType
+
 from picai_baseline.unet.training_setup.image_reader import SimpleITKDataset
 
 
@@ -121,6 +122,6 @@ def prepare_datagens(args, fold_id):
     train_ldr = DataLoaderFromDataset(train_ds, 
         batch_size=args.batch_size, num_threads=args.num_threads, infinite=True, shuffle=True)
     valid_ldr = DataLoaderFromDataset(valid_ds, 
-        batch_size=1, num_threads=args.batch_size, infinite=False, shuffle=False)
+        batch_size=args.batch_size, num_threads=args.num_threads, infinite=False, shuffle=False)
 
     return train_ldr, valid_ldr, class_weights.astype(np.float32)

--- a/src/picai_baseline/unet/training_setup/data_generator.py
+++ b/src/picai_baseline/unet/training_setup/data_generator.py
@@ -121,6 +121,6 @@ def prepare_datagens(args, fold_id):
     train_ldr = DataLoaderFromDataset(train_ds, 
         batch_size=args.batch_size, num_threads=args.num_threads, infinite=True, shuffle=True)
     valid_ldr = DataLoaderFromDataset(valid_ds, 
-        batch_size=1, num_threads=1, infinite=False, shuffle=False)
+        batch_size=1, num_threads=args.batch_size, infinite=False, shuffle=False)
 
     return train_ldr, valid_ldr, class_weights.astype(np.float32)


### PR DESCRIPTION
Evaluate models by processing the detection maps per batch, rather than collecting all model predictions in RAM.