### PR TITLE
Bugfix one-hot encoding of targets

### DIFF
--- a/src/picai_baseline/unet/training_setup/loss_functions/focal.py
+++ b/src/picai_baseline/unet/training_setup/loss_functions/focal.py
@@ -29,8 +29,6 @@ class FocalLoss(nn.Module):
 
     def forward(self, inputs, targets):
         inputs = torch.sigmoid(inputs)
-        targets = F.one_hot(targets, num_classes=self.num_classes).float()
-        targets = torch.moveaxis(targets, (0, 1, 2, 3, 4), (0, 2, 3, 4, 1))
         ce_loss = F.binary_cross_entropy(inputs, targets, reduction="none")
         p_t = (inputs * targets) + ((1 - inputs) * (1 - targets))
         loss = ce_loss * ((1 - p_t) ** self.gamma)


### PR DESCRIPTION
The targets for the UNet baseline became `(B, 1, D, H, W, C)` after the one-hot encoding, which includes a dummy dimension that should not be there. Subsequently, the `moveaxes` is incorrect. This fixes the one-hot encoding and performs this outside the loss function, to enable easier model development with e.g. different loss functions.