### PR TITLE
Changed download links to use the zenodo api url

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Unless specified otherwise, this tutorial assumes that the [PI-CAI: Public Train
 
 ```bash
 # download all folds
-curl -C - "https://zenodo.org/record/6624726/files/picai_public_images_fold0.zip?download=1" --output picai_public_images_fold0.zip
-curl -C - "https://zenodo.org/record/6624726/files/picai_public_images_fold1.zip?download=1" --output picai_public_images_fold1.zip
-curl -C - "https://zenodo.org/record/6624726/files/picai_public_images_fold2.zip?download=1" --output picai_public_images_fold2.zip
-curl -C - "https://zenodo.org/record/6624726/files/picai_public_images_fold3.zip?download=1" --output picai_public_images_fold3.zip
-curl -C - "https://zenodo.org/record/6624726/files/picai_public_images_fold4.zip?download=1" --output picai_public_images_fold4.zip
+curl -C - "https://zenodo.org/api/records/6624726/files/picai_public_images_fold0.zip/content" --output picai_public_images_fold0.zip
+curl -C - "https://zenodo.org/api/records/6624726/files/picai_public_images_fold1.zip/content" --output picai_public_images_fold1.zip
+curl -C - "https://zenodo.org/api/records/6624726/files/picai_public_images_fold2.zip/content" --output picai_public_images_fold2.zip
+curl -C - "https://zenodo.org/api/records/6624726/files/picai_public_images_fold3.zip/content" --output picai_public_images_fold3.zip
+curl -C - "https://zenodo.org/api/records/6624726/files/picai_public_images_fold4.zip/content" --output picai_public_images_fold4.zip
 
 # unzip all folds
 unzip picai_public_images_fold0.zip -d /input/images/


### PR DESCRIPTION
The previous download links do not download the zips anymore. Instead, they download short HTML snippets like this:

```!doctype html>
<html lang=en>
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to the target URL: <a href="/records/6624726/files/picai_public_images_fold0.zip">/records/6624726/files/picai_public_images_fold0.zip</a>. If not, click the link.
```

The updated download links using the zenodo API URL download the zipped data folders as intended. 